### PR TITLE
Prevent cellInLastRow activation for Headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ class MuiTable extends Component {
       [classes.cellDisabled]: isDisabled,
       [classes.cellHeader]: isHeader,
       [classes.cellInLastColumn]: columnIndex === columns.length - 1,
-      [classes.cellInLastRow]: rowIndex === (data ? data.length : 0)
+      [classes.cellInLastRow]: !isHeader && rowIndex === (data ? data.length : 0)
     });
 
     const hasCellClick = !isHeader && onCellClick;


### PR DESCRIPTION
This prevents a visual artifact that typically occurs if you have a search attached to the table and when the items go from N > 0 to N = 0 the border change causes the header text to shift 1px up or down. The border change should really only apply to the non-header cells.