### PR TITLE
Fixed column.onHeaderClick implementation and types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,12 +4,14 @@ import * as React from "react";
 
 export type CellClickEventHandler<HTMLElement, TRow> = (
   event: React.MouseEvent<HTMLElement>,
-  props: {
-    column: IMuiVirtualizedTableColumn<TRow>;
-    rowData?: TRow;
-    data?: TRow[];
-  }
+  props: IHeaderClickProps<TRow>
 ) => void;
+
+export interface IHeaderClickProps<TRow> {
+  column: IMuiVirtualizedTableColumn<TRow>;
+  rowData?: TRow;
+  data?: TRow[];
+}
 
 export type ICellPropsProducer<TRow> =
   | TableCellProps
@@ -39,7 +41,7 @@ export interface IMuiVirtualizedTableColumn<TRow = any> {
   /**
    * Callback when header is clicked on (has precedence over `onHeaderClick` on table)
    */
-  onHeaderClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  onHeaderClick?: CellClickEventHandler<HTMLElement, TRow>;
 
   /**
    * Width of cell.

--- a/src/index.js
+++ b/src/index.js
@@ -280,7 +280,7 @@ class MuiTable extends Component {
     const isClickable = hasCellClick || hasCellDoubleClick || hasCellContextMenu || column.onClick;
 
     const className = classNames(classes.cell, {
-      [classes.cellClickable]: isClickable,        
+      [classes.cellClickable]: isClickable,
       [classes.cellHovered]: isHovered,
       [classes.cellSelected]: isSelected,
       [classes.cellDisabled]: isDisabled,
@@ -330,7 +330,7 @@ class MuiTable extends Component {
             direction={orderDirection}
             onClick={event =>
               column.onHeaderClick
-                ? column.onHeaderClick(event)
+                ? column.onHeaderClick(event, { column })
                 : onHeaderClick(event, { column })
             }
           >

--- a/stories/basic.js
+++ b/stories/basic.js
@@ -336,8 +336,8 @@ storiesOf('Basic', module)
               {
                 name: 'jobTitle',
                 header: 'Job Title (custom)',
-                onHeaderClick: () => {
-                  alert('Job Title header clicked');
+                onHeaderClick: (event, { column }) => {
+                  alert(`Job Title header clicked; column.name: ${column.name}`);
                 }
               }
             ]}


### PR DESCRIPTION
The column.onHeaderClick implementation that was added recently had the intention of passing through the click event, but took away the column data. 

This fixes the column.onHeaderClick to make the implementation consistent with the onHeaderClick on the table props. I also added a TS interface that represents the props that can be passed through a CellClickEventHandler so they can be hooked up when a user implements column.onHeaderClick.