### PR TITLE
Updated column.onHeaderClick to allow for boolean values.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ export interface IMuiVirtualizedTableColumn<TRow = any> {
   /**
    * Callback when header is clicked on (has precedence over `onHeaderClick` on table)
    */
-  onHeaderClick?: CellClickEventHandler<HTMLElement, TRow>;
+  onHeaderClick?: CellClickEventHandler<HTMLElement, TRow> | boolean;
 
   /**
    * Width of cell.


### PR DESCRIPTION
Sorry for missing this. This should help match the full implementation of column.onHeaderClick - setting a column definition's `onHeaderClick` property to `false` successfully disables the column's click handler in the event that `onHeaderClick` is specified as a property on the MuiTable.

I ran across this when implementing the 3.0.0-1 table locally and attempted to disable a column, the associated type error is resolved with this change.