### PR TITLE
Change withStyles->makeStyles. Add missing effect dependency.  Remove…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-virtualized-table",
-  "version": "3.0.0-4",
+  "version": "3.0.0-5",
   "description": "Material-UI table with windowing, row/column freezing, and more",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -7,16 +7,15 @@ import TableCell from '@material-ui/core/TableCell';
 import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
-import { withStyles } from '@material-ui/core';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Draggable from 'react-draggable';
 import { calcColumnWidth } from './utils';
 
 const FOOTER_BORDER_HEIGHT = 1;
 
-export const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   table: {
     boxSizing: 'border-box',
-    border: `1px solid ${theme.palette.text.lightDivider}`,
 
     '& .topLeftGrid': {
       backgroundColor:
@@ -71,7 +70,6 @@ export const styles = theme => ({
     boxSizing: 'border-box',
     display: 'flex',
     alignItems: 'center'
-    // borderRight: `1px solid ${theme.palette.text.lightDivider}`,
   },
   cellClickable: {
     cursor: 'pointer'
@@ -124,7 +122,7 @@ export const styles = theme => ({
     justifyContent: 'center',
     alignItems: 'center'
   }
-});
+}));
 
 const calculateWidths = ({ resizable, columns: Columns }) => {
   var widths = [];
@@ -177,7 +175,7 @@ const useCellRenderer = ({
 
   React.useEffect(() => {
     recomputeGridSize();
-  }, [hoveredColumn, hoveredRowData, widths]);
+  }, [recomputeGridSize, hoveredColumn, hoveredRowData, widths]);
 
   const resizableColumnWidths = React.useCallback(
     (index, columns, tableWidth) => widths[columns[index].name] * tableWidth,
@@ -271,7 +269,6 @@ const useCellRenderer = ({
               defaultClassNameDragging={classes.DragHandleActive}
               onDrag={handleDrag(column.name)}
               position={{ x: 0 }}
-              zIndex={999}
             >
               <span className={classes.DragHandleIcon}>⋮</span>
             </Draggable>
@@ -352,7 +349,6 @@ const useCellRenderer = ({
               defaultClassNameDragging='DragHandleActive'
               onDrag={handleDrag(column.name)}
               position={{ x: 0 }}
-              zIndex={999}
             >
               <span className='DragHandleIcon'>⋮</span>
             </Draggable>
@@ -367,7 +363,7 @@ const useCellRenderer = ({
   return { cellRenderer, columnWidth: getColumnWidth };
 };
 
-function MuiTable({
+export default function MuiTable({
   data,
   columns,
   width,
@@ -379,13 +375,12 @@ function MuiTable({
   fixedColumnCount = 0,
   rowHeight = 48,
   style,
-  theme,
   columnWidth,
   includeHeaders = false,
   isCellHovered,
   isCellSelected,
   isCellDisabled,
-  classes,
+  classes: Classes,
   orderBy,
   orderDirection,
   onHeaderClick,
@@ -396,11 +391,14 @@ function MuiTable({
   cellProps,
   ...other
 }) {
+  const classes = useStyles({ classes: Classes });
+  const theme = useTheme();
+
   const multiGrid = React.useRef(null);
 
   const recomputeGridSize = React.useCallback(
     () => multiGrid.current && multiGrid.current.recomputeGridSize(),
-    [multiGrid.current]
+    [multiGrid]
   );
 
   React.useEffect(() => {
@@ -515,4 +513,3 @@ MuiTable.propTypes = {
   style: PropTypes.object
 };
 
-export default withStyles(styles, { withTheme: true })(MuiTable);


### PR DESCRIPTION
This PR uses makeStyles instead of withStyles.  I also ran the code through typescript validation and found a few other items that needed fixed.

- Bump version 3.0.0-4 -> 3.0.0-5
- Change withStyles to makeStyles
- Remove unused border (theme.palette.text.lightDivider does not exist, so this was removed)
- Add missing recomputeGrid useEffect dependency.
- Remove zIndex={999} prop from Draggable as this is not a valid prop.
- Don't use mutable multigrid.current prop in React.useEffect dependency array.

May also resolve https://github.com/techniq/mui-virtualized-table/issues/45 if that turns out to be an actual issue.